### PR TITLE
Fixed TODO is not a valid command error for when users try to install…

### DIFF
--- a/wisper-rabbitmq.gemspec
+++ b/wisper-rabbitmq.gemspec
@@ -8,8 +8,8 @@ Gem::Specification.new do |spec|
   spec.version       = Wisper::RabbitMQ::VERSION
   spec.authors       = ["Kris Leech"]
   spec.email         = ["kris.leech@gmail.com"]
-  spec.summary       = %q{TODO: Write a short summary. Required.}
-  spec.description   = %q{TODO: Write a longer description. Optional.}
+  spec.summary       = "Relay Wisper events to RabbitMQ"
+  spec.description   = ""
   spec.homepage      = ""
   spec.license       = "MIT"
 


### PR DESCRIPTION
… the gem.

This was the error: "The gemspec at .../ruby-2.2.1/bundler/gems/wisper-rabbitmq-4a38ab2ddbd6/wisper-rabbitmq.gemspec is not valid. The validation error was '"FIXME" or "TODO" is not a description'."

Removing the TODOs from the .gemspec file and running "bundle update" and then "bundle install" fixed the error.

Pull requesting the fix. :-)
